### PR TITLE
Clamp zero scale in act quant kernel

### DIFF
--- a/inference/kernel.py
+++ b/inference/kernel.py
@@ -24,6 +24,7 @@ def act_quant_kernel(x_ptr, y_ptr, s_ptr, BLOCK_SIZE: tl.constexpr):
     offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     x = tl.load(x_ptr + offs).to(tl.float32)
     s = tl.max(tl.abs(x)) / 448.
+    s = tl.where(s == 0, 1e-8, s)
     y = x / s
     y = y.to(y_ptr.dtype.element_ty)
     tl.store(y_ptr + offs, y)


### PR DESCRIPTION
## Summary
- Clamp activation quantization scale to 1e-8 when zero to avoid division by zero

## Testing
- `python -m py_compile inference/kernel.py`
- `pytest`
- `python - <<'PY'...act_quant...` *(fails: 0 active drivers ([]). There should only be one.)*

------
https://chatgpt.com/codex/tasks/task_b_68b8fec1f464832bae0675a3d48c9c91

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved numerical stability in activation quantization to prevent division-by-zero scenarios. This reduces occurrences of NaN/Inf values and avoids potential crashes during inference, especially on edge cases like all-zero inputs. Behavior and results remain consistent for normal inputs, with no changes to public interfaces or configuration required. Users should experience more reliable and robust model execution without any impact on expected outputs under typical conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->