### PR TITLE
Remove premature generation call before weight loading

### DIFF
--- a/inference/generate.py
+++ b/inference/generate.py
@@ -115,7 +115,6 @@ def main(
     with torch.device("cuda"):
         model = Transformer(args)
     tokenizer = AutoTokenizer.from_pretrained(ckpt_path)
-    tokenizer.decode(generate(model, [tokenizer.encode("DeepSeek")], 2, -1, 1.)[0])
     load_model(model, os.path.join(ckpt_path, f"model{rank}-mp{world_size}.safetensors"))
 
     if interactive:


### PR DESCRIPTION
## Summary
- remove early token generation call before model weights are loaded to ensure output generation only occurs after initialization

## Testing
- `python -m py_compile inference/generate.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_b_68b8fece31e4832b9e94ec3498025357

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Removed an unnecessary token generation during startup, reducing cold-start latency and initial overhead.
  - Users should experience faster launch times and improved responsiveness on first interaction.
  - Lowers initial CPU/GPU utilization and minimizes superfluous console output at initialization.
  - No changes to interactive or batch generation behavior; functionality remains the same.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->